### PR TITLE
Add Dockerfile and README instructions for Jupyter-based StarVector e…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,34 @@
+FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
+
+# Install necessary dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    git \
+    vim \
+    build-essential \
+    libcairo2 \
+    cuda-compiler-12-4 \
+    libaio-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+
+# Install Jupyter Notebook, clone and install star-vector and dependencies
+RUN pip install --upgrade pip && pip install jupyter deepspeed \
+    && git clone https://github.com/joanrod/star-vector.git /tmp/star-vector \
+    && pip install /tmp/star-vector \
+    && rm -rf /tmp/star-vector
+
+# Cleanup unneeded packages
+RUN apt-get purge -y --auto-remove \
+    git \
+    build-essential \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Expose Jupyter Notebook port
+EXPOSE 8888
+
+WORKDIR /workspace
+
+# Launch Jupyter Notebook
+CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root"]

--- a/docker/Image2SVG Generation Example.ipynb
+++ b/docker/Image2SVG Generation Example.ipynb
@@ -1,0 +1,95 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "659c25fd-2a10-4010-ae4c-bf6c42c59a6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from PIL import Image\n",
+    "from starvector.model.starvector_arch import StarVectorForCausalLM\n",
+    "from starvector.data.util import process_and_rasterize_svg\n",
+    "import torch\n",
+    "\n",
+    "model_name = \"starvector/starvector-1b-im2svg\"\n",
+    "#model_name = \"starvector/starvector-8b-im2svg\"\n",
+    "\n",
+    "starvector = StarVectorForCausalLM.from_pretrained(model_name, torch_dtype=torch.float16)\n",
+    "\n",
+    "starvector.cuda()\n",
+    "starvector.eval()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a3ae9d8-7e7c-4eba-b830-4f45d68f7b5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_pil = Image.open('../assets/examples/sample-18.png')\n",
+    "\n",
+    "image = starvector.process_images([image_pil])[0].cuda()\n",
+    "batch = {\"image\": image}\n",
+    "\n",
+    "raw_svg = starvector.generate_im2svg(batch, max_length=5000)[0]\n",
+    "svg, raster_image = process_and_rasterize_svg(raw_svg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a100757-c512-4e4b-a05d-f5a74fbf9133",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import SVG, display\n",
+    "\n",
+    "display(image_pil)\n",
+    "display(SVG(svg))\n",
+    "display(raster_image)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b13dd1af-d579-452a-96f8-f0fae5289d24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del starvector\n",
+    "torch.cuda.empty_cache()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6cf1d4d9-2798-4b67-9942-7b3a5cf03122",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,70 @@
+## 🐳 Docker Setup for StarVector
+
+To simplify the setup process and avoid dependency issues, you can use a Docker container to run **StarVector** in a self-contained environment. The Dockerfile and this guide are located in the `docker/` subfolder of the repository.
+
+---
+
+### 🛠️ Build the Docker Image
+
+1. **Clone the Repository**:
+
+   ```bash
+   git clone https://github.com/joanrod/star-vector.git
+   cd star-vector/docker
+   ```
+
+2. **Build the Image**:
+
+   ```bash
+   docker build -t starvector:latest .
+   ```
+
+---
+
+### 🚀 Run the Docker Container
+
+```bash
+docker run -it \
+  --gpus all \
+  -p 8888:8888 \
+  -v $(pwd)/..:/workspace \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  --env HUGGING_FACE_HUB_TOKEN=<your_huggingface_token> \
+  --name starvector \
+  starvector:latest
+```
+
+**Options explained:**
+
+- `--gpus all`: Enables GPU acceleration (requires [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html))
+- `-p 8888:8888`: Exposes Jupyter Notebook to your host machine
+- `-v $(pwd)/..:/workspace`: Mounts the project root directory into the container
+- `-v ~/.cache/huggingface:/root/.cache/huggingface`: Shares Hugging Face cache for offline usage and faster loading
+- `--env HUGGING_FACE_HUB_TOKEN=...`: Sets an environment variable with your token for accessing gated models
+- `--name starvector`: Assigns a name to the container
+
+---
+
+### 🔑 Hugging Face Token
+
+**StarVector models depend on** the Hugging Face model `bigcode/starcoderbase-1b`, which is a gated model.
+
+To access it, you need a **Hugging Face token** with the following permission:
+
+> ✅ Read access to contents of all public gated repos you can access
+
+You can generate it here: https://huggingface.co/settings/tokens
+
+---
+
+### 🌐 Access Jupyter Notebook
+
+After the container starts, you'll see a URL like:
+
+```
+http://127.0.0.1:8888/?token=<your_token_here>
+```
+
+Copy and open it in your browser to start using **StarVector** in a notebook environment.
+
+---


### PR DESCRIPTION
Dockerfile and detailed usage instructions to simplify setting up and running **StarVector** in a consistent environment.

What’s included:
- Dockerfile based on **pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel**
- Installs all required system and Python dependencies (Jupyter, Deepspeed, libcairo, nvcc)
- **README** section (in docker/) with build/run instructions
- Hugging Face token info (required for starcoderbase-1b dependency)

This makes it much easier for users and contributors to start experimenting with **StarVector**.

Tested on: Docker + NVIDIA GPUs (Fedora 41 Server)