### PR TITLE
lazy import for deepspeed & use transformer.check for flash_attn

### DIFF
--- a/starvector/model/llm/starcoder.py
+++ b/starvector/model/llm/starcoder.py
@@ -3,6 +3,7 @@ from transformers import (
     AutoConfig, 
     AutoModelForCausalLM, 
     AutoTokenizer,
+    utils
     )
 
 class StarCoderModel(nn.Module):
@@ -21,10 +22,11 @@ class StarCoderModel(nn.Module):
         model_config.eos_token_id = self.tokenizer.eos_token_id
         model_config.pad_token_id = self.tokenizer.pad_token_id
         model_config.bos_token_id = self.tokenizer.bos_token_id
-        try:
+        
+        if utils.is_flash_attn_2_available():
             model_config.flash_attention = config.use_flash_attn
             model_config._attn_implementation = "flash_attention_2"
-        except ImportError:
+        else:
             config.use_flash_attn = False
         
         # model = GPTBigCodeForCausalLM(config=model_config)

--- a/starvector/train/util.py
+++ b/starvector/train/util.py
@@ -29,7 +29,6 @@ from transformers import (
     AutoModelForCausalLM
 )
 from starvector.model.starvector_arch import StarVectorConfig, StarVectorForCausalLM
-from starvector.train.zero_to_fp32 import convert_zero_checkpoint_to_fp32_state_dict
 
 
 def is_deepspeed(checkpoint_dir):
@@ -39,6 +38,7 @@ def is_deepspeed(checkpoint_dir):
 def consolidate_deepspeed_checkpoint(checkpoint_dir):
     path_state_dict = os.path.join(checkpoint_dir, 'weights.pt')
     if not os.path.exists(path_state_dict):
+        from starvector.train.zero_to_fp32 import convert_zero_checkpoint_to_fp32_state_dict
         convert_zero_checkpoint_to_fp32_state_dict(checkpoint_dir, path_state_dict)
 
 def load_checkpoint(model, checkpoint_dir):


### PR DESCRIPTION
This PR is to enable direct execution of python scripts/quickstart.py [for inference only] without installing deepspeed and flash-attention2